### PR TITLE
Add comment style and indentation pattern

### DIFF
--- a/settings/language-smali.cson
+++ b/settings/language-smali.cson
@@ -1,0 +1,5 @@
+'.source.smali':
+  'editor':
+    'commentStart': '# '
+    'increaseIndentPattern': '^\\s*\.(method|packed|sparse|array).*$'
+    'decreaseIndentPattern': '^\\s*\.end.*$'


### PR DESCRIPTION
This language-smali plugin is great and helps a lot when editing smali codes generated from apktool using Atom!
This pull request adds comment style and indentation patterns such that atom can comment correctly when toggling line comment.
